### PR TITLE
Fix the multi-line message support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ nosetests.xml
 .project
 .pydevproject
 .venv
+
+# PyCharm
+.idea

--- a/cowpy/cow.py
+++ b/cowpy/cow.py
@@ -88,47 +88,25 @@ class Cowacter(object):
                               "          {tongue} ||----w |\n"
                               "           ||     ||")
 
-    def _maxlen(self, lines):
-        m = -1
-        for line in lines:
-            l = len(line)
-            if l > m:
-                m = l
-
-        return m
-
     def _bubble(self, message):
-
         lines = message.splitlines()
-        max = self._maxlen(lines)
-        max2 = max + 2  # border spacing
-        fmt = "{0} {1} {2}{3}\n"
+        content_len = max(len(line) for line in lines)
+        border_len = content_len + 2
+        fmt = "{0} {1} {2}\n"
         res = ""
 
-        def pad(llen):
-            return ' ' * (max - llen)
-
         # Try to kick out just the balloon first.
-        res += " {0} \n".format('_' * max2)
+        res += " {0} \n".format('_' * border_len)
+
         if len(lines) > 1:
-            if len(lines) == 2:
-                line = lines.pop(0)
-                res += fmt.format('/', line, pad(len(line)), '\\')
-                line = lines.pop(0)
-                res += fmt.format('\\', line, pad(len(line)), '/')
-            else:
-                line = lines.pop(0)
-                lastline = lines.pop(0)
-                res += fmt.format('/', line, pad(len(line)), '\\')
-                for line in lines:
-                    res += fmt.format('|', line, pad(len(line)), '|')
-
-                res += fmt.format('\\', lastline, pad(len(lastline)), '/')
+            res += fmt.format('/', lines[0].ljust(content_len), '\\')
+            for i in range(1, len(lines) - 1):
+                res += fmt.format('|', lines[i].ljust(content_len), '|')
+            res += fmt.format('\\', lines[-1].ljust(content_len), '/')
         else:
-            line = lines.pop()
-            res += fmt.format('<', line, pad(len(line)), '>')
+            res += fmt.format('<', lines[0].ljust(content_len), '>')
 
-        res += " {0} \n".format('-' * max2)
+        res += " {0} \n".format('-' * border_len)
         return res
 
     def milk(self, msg):

--- a/test/qtest.py
+++ b/test/qtest.py
@@ -38,8 +38,17 @@ cheese = cow.Moose(thoughts=True, tongue=True, eyes='dead')
 msg = cheese.milk("My witty mesage with several attributes")
 print(msg)
 
-# Create a random cow with a message
+# Create a random cow with a one-line message
 msg = cow.milk_random_cow("A random message for fun")
+print(msg)
+
+# Create a random cow with a multi-line message
+msg = cow.milk_random_cow("\n".join([
+    "A random multi-line message:",
+    "1. for fun",
+    "2. for fun",
+    "3. and for fun"
+]))
 print(msg)
 
 # all the eye options


### PR DESCRIPTION
Repro:
```python
from cowpy import cow
msg = cow.milk_random_cow("\n".join([
    "A random multi-line message:",
    "1. for fun",
    "2. for fun",
    "3. and for fun"
]))
print(msg)
```

Expected Bubble:
```
 ------------------------------ 
/ A random multi-line message: \
| 1. for fun                   |
| 2. for fun                   |
\ 3. and for fun               /
 ------------------------------ 
```

Actual Bubble:
```
 ------------------------------ 
/ A random multi-line message: \
| 2. for fun                   |
| 3. and for fun               |
\ 1. for fun                   /
 ------------------------------ 
```

Change Details:
- Fix the multi-line mesage support.
- Simplify the `_bubble` generation logic.