### PR TITLE
Update `pyproject.toml` config file with `cowpy` CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,6 @@ twine = "^3.4.2"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.scripts]
+cowpy = "cowpy:main"


### PR DESCRIPTION
Currently, `pip install cowpy` is not installing `cowpy` CLI. I guess this is due to missing config in `pyproject.toml` file. This PR fixes it. I am not sure if it works in Windows though. I have tested in MacOS and Linux.